### PR TITLE
refactor: Simplify names of collection methods

### DIFF
--- a/.changeset/true-dodos-share.md
+++ b/.changeset/true-dodos-share.md
@@ -1,0 +1,24 @@
+---
+"@juun-roh/cesium-utils": patch
+---
+
+Refactor Collection
+
+refactor: Simplify names of collection methods
+
+* New Functionality
+
+1. Iterator Support  
+Now supports iterator protocol.
+
+2. Expand Standard Array API  
+Add `map`, `find`.
+
+* API Streamlining:  
+Shorter, more intuitive method names. (`contains`, `get`, `first`, `update`)  
+Consistent parameter naming with `by` for tag-based operations.  
+Naming consistency with `from`/`to` in update().
+
+* Consistant return type to support chaining
+Visibility operations (show, hide, toggle) now return this for chaining.  
+setProperty returns this instead of count for consistent pattern.

--- a/src/utils/terrain/visualizer/terrain-visualizer.ts
+++ b/src/utils/terrain/visualizer/terrain-visualizer.ts
@@ -89,7 +89,7 @@ export class TerrainVisualizer {
    * Clears all visualizations.
    */
   clear(): void {
-    this._collection.removeByTag(this._collection.getTags());
+    this._collection.remove(this._collection.tags);
   }
 
   /**
@@ -99,7 +99,7 @@ export class TerrainVisualizer {
   show(level: number = 15): void {
     if (!this._hybridTerrain) return;
 
-    this._collection.removeByTag(TerrainVisualizer.tag.grid);
+    this._collection.remove(TerrainVisualizer.tag.grid);
 
     this._level = level;
     const tilingScheme = this._hybridTerrain.tilingScheme;
@@ -221,7 +221,7 @@ export class TerrainVisualizer {
    * Hides the tile grid.
    */
   hide(): void {
-    this._collection.removeByTag(TerrainVisualizer.tag.grid);
+    this._collection.remove(TerrainVisualizer.tag.grid);
 
     if (this._tileCoordinatesLayer) {
       this._viewer.imageryLayers.remove(this._tileCoordinatesLayer);


### PR DESCRIPTION
* New Functionality

1. Iterator Support Now supports iterator protocol.

2. Expand Standard Array API Add `map`, `find`.

* API Streamlining: Shorter, more intuitive method names. (`contains`, `get`, `first`, `update`) Consistent parameter naming with `by` for tag-based operations. Naming consistency with `from`/`to` in update().

* Consistant return type to support chaining Visibility operations (show, hide, toggle) now return this for chaining. setProperty returns this instead of count for consistent pattern.