### PR TITLE
refactor: Rename class

### DIFF
--- a/.changeset/easy-mirrors-clean.md
+++ b/.changeset/easy-mirrors-clean.md
@@ -1,0 +1,16 @@
+---
+"@juun-roh/cesium-utils": patch
+---
+
+Refactoring Classes
+
+refactor: Rename class
+
+* Rename `TerrainAreas` as `TerrainAreaCollection`.  
+The class provides collection-like methods, so renamed it to be more consistent.  
+
+* Rename the member `_provider` as `_terrainProvider` of `TerrainArea`.  
+To have more aligned form of variables.
+
+* Update Documents.  
+Some of the existing documents were incompatible with the code.

--- a/src/__tests__/require-import/cjs-require.test.cjs
+++ b/src/__tests__/require-import/cjs-require.test.cjs
@@ -1,8 +1,6 @@
 const { Viewer } = require('cesium');
+const { describe, expect, test } = require('vitest/dist/index.js');
 const utils = require('../../../dist/index.cjs');
-const { test } = require('vitest/dist/index.js');
-const { expect } = require('vitest/dist/index.js');
-const { describe } = require('vitest/dist/index.js');
 
 describe('Common JS require test with Cesium', () => {
   test('require from Cesium', () => {
@@ -10,12 +8,15 @@ describe('Common JS require test with Cesium', () => {
   });
 
   test('require from dist', () => {
-    expect(utils.cloneViewer).toBeDefined();
     expect(utils.Collection).toBeDefined();
     expect(utils.HybridTerrainProvider).toBeDefined();
     expect(utils.TerrainArea).toBeDefined();
-    expect(utils.TerrainAreas).toBeDefined();
+    expect(utils.TerrainAreaCollection).toBeDefined();
     expect(utils.TerrainVisualizer).toBeDefined();
+
+    expect(utils.cloneViewer).toBeDefined();
+    expect(utils.computeRectangle).toBeDefined();
+    expect(utils.isGetterOnly).toBeDefined();
     expect(utils.syncCamera).toBeDefined();
   })
 })

--- a/src/__tests__/require-import/esm-import.test.mjs
+++ b/src/__tests__/require-import/esm-import.test.mjs
@@ -8,12 +8,15 @@ describe('ECMA Script Module import test with Cesium', () => {
   });
 
   test('import from dist', () => {
-    expect(utils.cloneViewer).toBeDefined();
     expect(utils.Collection).toBeDefined();
     expect(utils.HybridTerrainProvider).toBeDefined();
     expect(utils.TerrainArea).toBeDefined();
-    expect(utils.TerrainAreas).toBeDefined();
+    expect(utils.TerrainAreaCollection).toBeDefined();
     expect(utils.TerrainVisualizer).toBeDefined();
+
+    expect(utils.cloneViewer).toBeDefined();
+    expect(utils.computeRectangle).toBeDefined();
+    expect(utils.isGetterOnly).toBeDefined();
     expect(utils.syncCamera).toBeDefined();
   });
 });

--- a/src/__tests__/terrain/terrain-area-collection.test.ts
+++ b/src/__tests__/terrain/terrain-area-collection.test.ts
@@ -1,7 +1,7 @@
 import { EllipsoidTerrainProvider } from 'cesium';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { TerrainArea, TerrainAreas } from '@/terrain/index.js';
+import { TerrainArea, TerrainAreaCollection } from '@/terrain/index.js';
 import type { TileRange } from '@/terrain/terrain.types.js';
 
 describe('TerrainAreas', () => {
@@ -9,7 +9,7 @@ describe('TerrainAreas', () => {
     const tileRanges = new Map<number, TileRange>();
     tileRanges.set(i, { start: { x: i, y: i }, end: { x: i, y: i } });
     return {
-      provider: new EllipsoidTerrainProvider(),
+      terrainProvider: new EllipsoidTerrainProvider(),
       tileRanges,
     };
   };
@@ -17,7 +17,7 @@ describe('TerrainAreas', () => {
     return new TerrainArea(option);
   };
 
-  const areas: TerrainAreas = new TerrainAreas();
+  const areas: TerrainAreaCollection = new TerrainAreaCollection();
 
   beforeEach(() => {
     areas.removeAll();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Collection from './collection/collection.js';
 import { HybridTerrainProvider } from './terrain/hybrid-terrain-provider.js';
 import { computeRectangle } from './terrain/terrain.utils.js';
 import { TerrainArea } from './terrain/terrain-area.js';
-import TerrainAreas from './terrain/terrain-areas.js';
+import TerrainAreaCollection from './terrain/terrain-area-collection.js';
 import { TerrainVisualizer } from './utils/terrain/index.js';
 import { isGetterOnly } from './utils/type-check.js';
 import { syncCamera } from './utils/viewer/index.js';
@@ -13,7 +13,7 @@ export {
   Collection,
   HybridTerrainProvider,
   TerrainArea,
-  TerrainAreas,
+  TerrainAreaCollection,
   TerrainVisualizer,
 };
 

--- a/src/terrain/index.ts
+++ b/src/terrain/index.ts
@@ -1,9 +1,9 @@
 import { HybridTerrainProvider } from './hybrid-terrain-provider.js';
 import { computeRectangle } from './terrain.utils.js';
 import { TerrainArea } from './terrain-area.js';
-import TerrainAreas from './terrain-areas.js';
+import TerrainAreaCollection from './terrain-area-collection.js';
 
-export { HybridTerrainProvider, TerrainArea, TerrainAreas };
+export { HybridTerrainProvider, TerrainArea, TerrainAreaCollection };
 
 export { computeRectangle };
 

--- a/src/terrain/terrain-area-collection.ts
+++ b/src/terrain/terrain-area-collection.ts
@@ -1,6 +1,11 @@
 import { TerrainArea } from './terrain-area.js';
 
-export default class TerrainAreas extends Array<TerrainArea> {
+/**
+ * @extends Array
+ * @class
+ * Collection-like Extended Array Class of `TerrainArea`.
+ */
+export default class TerrainAreaCollection extends Array<TerrainArea> {
   /**
    * Adds a new terrain area to the collection.
    * @param area A TerrainArea instance or constructor options
@@ -39,10 +44,12 @@ export default class TerrainAreas extends Array<TerrainArea> {
 
   /**
    * Removes a terrain area from the collection.
+   * @param area The terrain area to remove.
    */
   remove(area: TerrainArea): this;
   /**
    * Removes multiple terrain areas from the collection.
+   * @param areas The terrain areas to remove.
    */
   remove(areas: TerrainArea[]): this;
   remove(target: TerrainArea | TerrainArea[]): this {

--- a/src/terrain/terrain-area.ts
+++ b/src/terrain/terrain-area.ts
@@ -16,7 +16,7 @@ import { computeRectangle } from './terrain.utils.js';
  * `TerrainArea` pairs a provider with geographic bounds and level constraints.
  */
 export class TerrainArea {
-  private _provider: TerrainProvider;
+  private _terrainProvider: TerrainProvider;
   private _rectangle: Rectangle;
   private _tileRanges: Map<number, TileRange>;
   private _ready: boolean = false;
@@ -28,16 +28,16 @@ export class TerrainArea {
    * @param options Object describing initialization options
    */
   constructor(options: TerrainArea.ConstructorOptions) {
-    this._provider = options.provider;
+    this._terrainProvider = options.terrainProvider;
     this._tileRanges = options.tileRanges;
     this._credit = options.credit || 'custom';
     this._isCustom = options.isCustom !== undefined ? options.isCustom : true;
     this._rectangle = computeRectangle(
-      options.provider.tilingScheme,
+      options.terrainProvider.tilingScheme,
       options.tileRanges,
     );
     options.tileRanges.forEach((range, level) => {
-      this._provider.availability?.addAvailableTileRange(
+      this._terrainProvider.availability?.addAvailableTileRange(
         level,
         range.start.x,
         range.start.y,
@@ -56,7 +56,7 @@ export class TerrainArea {
    * @returns `true` if the tile is within bounds, `false` otherwise.
    */
   contains(x: number, y: number, level: number): boolean {
-    // If we're using tile ranges, ONLY allow tiles at the specified levels
+    // Allow ONLY tiles at the specified levels
     if (this._tileRanges.size > 0) {
       if (!this._tileRanges.has(level)) {
         return false;
@@ -71,8 +71,8 @@ export class TerrainArea {
       );
     }
 
-    // This code will only run if no tile ranges were specified
-    const tileRectangle = this._provider.tilingScheme.tileXYToRectangle(
+    // If no tile ranges were specified, compare with rectangle
+    const tileRectangle = this._terrainProvider.tilingScheme.tileXYToRectangle(
       x,
       y,
       level,
@@ -100,12 +100,12 @@ export class TerrainArea {
     if (
       !this._ready ||
       !this.contains(x, y, level) ||
-      !this._provider.getTileDataAvailable(x, y, level)
+      !this._terrainProvider.getTileDataAvailable(x, y, level)
     ) {
       return undefined;
     }
 
-    return this._provider.requestTileGeometry(x, y, level, request);
+    return this._terrainProvider.requestTileGeometry(x, y, level, request);
   }
 
   /**
@@ -116,9 +116,7 @@ export class TerrainArea {
    * @returns Undefined if not supported by the terrain provider, otherwise true or false.
    * @see {@link TerrainProvider.getTileDataAvailable} */
   getTileDataAvailable(x: number, y: number, level: number): boolean {
-    // If we're using explicit tile ranges, be strict about which levels are available
     if (this._tileRanges.size > 0) {
-      // Only return true for levels we've explicitly defined
       if (!this._tileRanges.has(level)) {
         return false;
       }
@@ -134,7 +132,7 @@ export class TerrainArea {
 
     // If no tile ranges are specified, defer to provider
     if (!this._ready) return false;
-    return this._provider.getTileDataAvailable(x, y, level) ?? false;
+    return this._terrainProvider.getTileDataAvailable(x, y, level) ?? false;
   }
 
   /** Checks if this terrain provider is marked as a custom provider. */
@@ -148,8 +146,8 @@ export class TerrainArea {
   }
 
   /** Gets the terrain provider for this terrain area. */
-  get provider(): TerrainProvider {
-    return this._provider;
+  get terrainProvider(): TerrainProvider {
+    return this._terrainProvider;
   }
 
   /** Gets available tile ranges with zoom levels set with this terrain area. */
@@ -176,7 +174,7 @@ export namespace TerrainArea {
   /** Initialization options for `TerrainArea` constructor. */
   export interface ConstructorOptions {
     /** The terrain provider for this area or a URL to create one from. */
-    provider: TerrainProvider;
+    terrainProvider: TerrainProvider;
     /**
      * Tile ranges by level when using tileRange type.
      * Keys are zoom levels, values define the range of tiles at that level.
@@ -219,7 +217,7 @@ export namespace TerrainArea {
     });
 
     const terrainArea = new TerrainArea({
-      provider,
+      terrainProvider: provider,
       tileRanges,
       credit,
     });

--- a/src/terrain/terrain.types.ts
+++ b/src/terrain/terrain.types.ts
@@ -1,7 +1,9 @@
 /** A range of tiles from `start` to `end` */
-export type TileRange = {
+type TileRange = {
   /** Top Left tile coordinates */
   start: { x: number; y: number };
   /** Bottom Right tile coordinates */
   end: { x: number; y: number };
 };
+
+export type { TileRange };

--- a/src/terrain/terrain.utils.ts
+++ b/src/terrain/terrain.utils.ts
@@ -1,6 +1,6 @@
 import { Rectangle, TilingScheme } from 'cesium';
 
-import { TileRange } from '@/terrain/terrain.types.js';
+import { TileRange } from './terrain.types.js';
 
 /**
  * Calculates a bounding rectangle that encompasses all the specified tile ranges.

--- a/src/utils/terrain/visualizer/terrain-visualizer.ts
+++ b/src/utils/terrain/visualizer/terrain-visualizer.ts
@@ -378,7 +378,7 @@ export namespace TerrainVisualizer {
     );
 
     if (show && area.tileRanges.size > 0) {
-      const { tilingScheme } = area.provider;
+      const { tilingScheme } = area.terrainProvider;
 
       let count = 0;
       area.tileRanges.forEach((range, level) => {


### PR DESCRIPTION
* Rename `TerrainAreas` as `TerrainAreaCollection`. The class provides collection-like methods, so renamed it to be more consistent.

* Rename the member `_provider` as `_terrainProvider` of `TerrainArea`. To have more aligned form of variables.

* Update Documents. Some of the existing documents were incompatible with the code.