### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/__mocks__/cesium.ts
+++ b/src/__mocks__/cesium.ts
@@ -3,6 +3,9 @@ import { vi } from 'vitest';
 // Deep merge utility
 function deepMerge(to: any, from: any) {
   Object.keys(from).forEach((key) => {
+    if (key === '__proto__' || key === 'constructor') {
+      return; // Skip prototype-polluting keys
+    }
     if (from[key] instanceof Object && key in to) {
       deepMerge(to[key], from[key]);
     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/juunie-roh/cesium-utils/security/code-scanning/1](https://github.com/juunie-roh/cesium-utils/security/code-scanning/1)

To fix the issue, we will modify the `deepMerge` function to block the special keys `__proto__` and `constructor` from being merged. This ensures that prototype pollution cannot occur, even if untrusted data is passed to the function. The fix will involve adding a check to skip these keys during the merge process.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
