### PR TITLE
feat: Add new highlight feature

### DIFF
--- a/.changeset/social-items-know.md
+++ b/.changeset/social-items-know.md
@@ -1,0 +1,18 @@
+---
+"@juun-roh/cesium-utils": patch
+---
+
+Highlight Feature Update
+
+feat: Add new highlight feature
+
+* New `Highlight` class for highlighting objects.  
+A multiton class that supports multi-viewer situation.  
+Handles mainly the object returned from `scene.pick()` or `drillPick()`.  
+
+* Fix mocks for tests.  
+Extend viewer mock to have collections. (primitives, entities, groundPrimives)  
+Add a simple collection mock.
+
+* New test conducted for `Highlight`.  
+In Progress.

--- a/src/__mocks__/cesium.ts
+++ b/src/__mocks__/cesium.ts
@@ -88,6 +88,8 @@ const createMockImageryLayers = (
 const createMockScene = (overrides?: Partial<CScene>) =>
   createMock(
     {
+      primitives: vi.fn().mockImplementation(() => ({})),
+      groundPrimitives: vi.fn().mockImplementation(() => ({})),
       requestRenderMode: true,
       globe: {
         enableLighting: false,
@@ -118,9 +120,10 @@ const createMockViewer = (overrides?: Partial<CViewer>) =>
 
       camera: createMockCamera(overrides?.camera),
       clock: createMockClock(overrides?.clock),
+      entities: vi.fn().mockImplementation(() => ({})),
+      imageryLayers: createMockImageryLayers(overrides?.imageryLayers),
       terrainProvider: { id: 'mockTerrainProvider' },
       scene: createMockScene(overrides?.scene),
-      imageryLayers: createMockImageryLayers(overrides?.imageryLayers),
     },
     overrides,
   );

--- a/src/__mocks__/collection.ts
+++ b/src/__mocks__/collection.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest';
+
+const Collection = vi.fn().mockImplementation(() => ({
+  add: vi.fn(),
+  remove: vi.fn(),
+}));
+
+export default Collection;

--- a/src/__tests__/viewer/highlight.test.ts
+++ b/src/__tests__/viewer/highlight.test.ts
@@ -1,0 +1,106 @@
+import { Color, Entity, GroundPrimitive, Viewer } from 'cesium';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockViewer } from '@/__mocks__/cesium.js';
+import { Highlight } from '@/viewer/highlight.js';
+
+vi.mock('../../collection/collection.ts', () => {
+  return import('../../__mocks__/collection.js');
+});
+
+describe('Highlight', () => {
+  let viewer: Viewer;
+  let highlight: Highlight;
+
+  beforeEach(() => {
+    viewer = createMockViewer() as unknown as Viewer;
+    highlight = Highlight.getInstance(viewer);
+  });
+
+  describe('getInstance', () => {
+    it('should create new instance from a single viewer only once', () => {
+      expect(highlight).toBeDefined();
+      expect(highlight.defaultColor).toEqual(Color.YELLOW.withAlpha(0.5));
+      expect(highlight.viewer).toEqual(viewer);
+
+      expect(Highlight.getInstance(viewer)).toEqual(highlight);
+    });
+
+    it('should create new instances each from different viewers', () => {
+      expect(Highlight.getInstance(viewer)).not.toEqual(
+        Highlight.getInstance(createMockViewer() as unknown as Viewer),
+      );
+    });
+  });
+
+  describe('releaseInstance', () => {
+    it('should release the instance associated with a viewer', () => {
+      const viewer = createMockViewer() as unknown as Viewer;
+      const highlight = Highlight.getInstance(viewer);
+      const clearAllSpy = vi.spyOn(highlight, 'clearAll');
+      const instancesMap = Highlight['instances'];
+      expect(instancesMap.has(viewer)).toBe(true);
+      expect(instancesMap.get(viewer)).toBe(highlight);
+
+      Highlight.releaseInstance(viewer);
+
+      expect(clearAllSpy).toHaveBeenCalledTimes(1);
+      expect(instancesMap.has(viewer)).toBe(false);
+
+      const newHighlight = Highlight.getInstance(viewer);
+      expect(newHighlight).not.toBe(highlight);
+      expect(instancesMap.get(viewer)).toBe(newHighlight);
+    });
+
+    it('should handle releasing non-existent instances', () => {
+      const viewer = createMockViewer() as unknown as Viewer;
+
+      expect(() => {
+        Highlight.releaseInstance(viewer);
+      }).not.toThrow();
+    });
+  });
+
+  describe('add', () => {
+    it('should return undefined if there is no picked object', () => {
+      expect(highlight.add(undefined)).toBe(undefined);
+    });
+
+    it('should handle different types of picked objects', () => {
+      highlight['_highlightEntity'] = vi.fn();
+      highlight['_highlightGroundPrimitive'] = vi.fn();
+      const entity = new Entity();
+      const objectWithId = { id: new Entity() };
+      const objectWithPrimitive = { primitive: new GroundPrimitive() };
+      const color = Color.RED;
+
+      highlight.add(entity, color);
+      expect(highlight['_highlightEntity']).toBeCalledWith(entity, color);
+
+      highlight.add(objectWithId, color);
+      expect(highlight['_highlightEntity']).toBeCalledWith(
+        objectWithId.id,
+        color,
+      );
+
+      highlight.add(objectWithPrimitive, color);
+      expect(highlight['_highlightGroundPrimitive']).toBeCalledWith(
+        objectWithPrimitive.primitive,
+        color,
+      );
+    });
+
+    it('should return and add result to active highlights set only when successful', () => {
+      const e = new Entity();
+      highlight['_highlightEntity'] = vi.fn().mockReturnValue(e);
+      expect(highlight.add(new Entity())).toBe(e);
+      expect(highlight.activeHighlights.size).toBe(1);
+
+      highlight['_highlightEntity'] = vi.fn().mockReturnValue(undefined);
+      expect(highlight.add(new Entity())).toBeUndefined();
+      expect(highlight.activeHighlights.size).toBe(1);
+    });
+  });
+
+  afterAll(() => vi.clearAllMocks());
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,13 @@ import TerrainAreaCollection from './terrain/terrain-area-collection.js';
 import { TerrainVisualizer } from './utils/terrain/index.js';
 import { isGetterOnly } from './utils/type-check.js';
 import { cloneViewer } from './viewer/clone.js';
+import { Highlight } from './viewer/highlight.js';
 import { syncCamera } from './viewer/index.js';
 
 // Classes
 export {
   Collection,
+  Highlight,
   HybridTerrainProvider,
   TerrainArea,
   TerrainAreaCollection,

--- a/src/viewer/highlight.ts
+++ b/src/viewer/highlight.ts
@@ -1,0 +1,275 @@
+import {
+  Cartesian3,
+  ClassificationType,
+  Color,
+  defined,
+  Entity,
+  EntityCollection,
+  GeometryInstance,
+  GroundPrimitive,
+  PerInstanceColorAppearance,
+  PrimitiveCollection,
+  Viewer,
+} from 'cesium';
+
+import Collection from '@/collection/collection.js';
+
+/**
+ * @class
+ * Multiton class for managing highlighted features in a Cesium scene.
+ * Maintains separate collections for different types of highlighted objects.
+ *
+ * @example
+ * ```
+ * // Setup
+ * const viewer1 = new Viewer('cesiumContainer1');
+ * const viewer2 = new Viewer('cesiumContainer2');
+ *
+ * const highlighter1 = Highlight.getInstance(viewer1);
+ * const highlighter2 = Highlight.getInstance(viewer2);
+ *
+ * // This highlight only affects viewer1
+ * highlighter1.add(someEntity, Color.RED);
+ *
+ * // This highlight only affects viewer2
+ * highlighter2.add(someEntity, Color.BLUE);
+ *
+ * // When done with viewers
+ * Highlight.releaseInstance(viewer1);
+ * Highlight.releaseInstance(viewer2);
+ * viewer1.destroy();
+ * viewer2.destroy();
+ * ```
+ */
+class Highlight {
+  private static instances = new Map<Viewer, Highlight>();
+  private _activeHighlights: Set<Entity | GroundPrimitive> = new Set();
+  private _defaultColor: Color = Color.YELLOW.withAlpha(0.5);
+  private _viewer: Viewer;
+  private _entities: Collection<EntityCollection, Entity>;
+  private _groundPrimitives: Collection<PrimitiveCollection, GroundPrimitive>;
+
+  /**
+   * Creates a new `Highlight` instance.
+   * @private Use {@link getInstance `Highlight.getInstance()`}
+   * @param viewer A viewer for the highlight collections to be derived from.
+   */
+  private constructor(viewer: Viewer) {
+    this._viewer = viewer;
+    this._entities = new Collection({
+      collection: viewer.entities,
+      tag: 'Highlight',
+    });
+    this._groundPrimitives = new Collection({
+      collection: viewer.scene.groundPrimitives,
+      tag: 'Highlight',
+    });
+  }
+
+  /**
+   * Gets or creates highlight instance from a viewer.
+   * @param viewer The viewer to get or create a new instance from.
+   */
+  static getInstance(viewer: Viewer): Highlight {
+    if (!Highlight.instances.has(viewer)) {
+      Highlight.instances.set(viewer, new Highlight(viewer));
+    }
+    return Highlight.instances.get(viewer)!;
+  }
+
+  /**
+   * Releases the highlight instance associated with a viewer.
+   * Call this when the viewer is being destroyed.
+   * @param viewer The viewer whose highlight instance should be released.
+   */
+  static releaseInstance(viewer: Viewer): void {
+    const instance = Highlight.instances.get(viewer);
+    if (instance) {
+      instance.clearAll(); // Clean up any remaining highlights
+      Highlight.instances.delete(viewer);
+    }
+  }
+
+  /**
+   * Highlights a picked object from the scene.
+   * @param picked The object returned from `scene.pick()` or `drillPick()`
+   * @param color Optional color for the highlight. Defaults to yellow with 0.5 alpha.
+   * @returns The newly created highlight object
+   */
+  add(
+    picked: any,
+    color: Color = this._defaultColor,
+  ): Entity | GroundPrimitive | undefined {
+    if (!defined(picked)) return undefined;
+
+    let highlight: Entity | GroundPrimitive | undefined;
+
+    if (this._activeHighlights.has(picked ?? picked.id ?? picked.primitive))
+      return;
+    if (picked instanceof Entity) {
+      highlight = this._highlightEntity(picked, color);
+    } else if (picked.id instanceof Entity) {
+      highlight = this._highlightEntity(picked.id, color);
+    } else if (picked.primitive instanceof GroundPrimitive) {
+      highlight = this._highlightGroundPrimitive(picked.primitive, color);
+    }
+
+    if (highlight) {
+      this._activeHighlights.add(highlight);
+    }
+
+    return highlight;
+  }
+
+  /**
+   * Clears a specific highlight.
+   * @param highlight The highlight object to clear
+   */
+  clear(highlight: Entity | GroundPrimitive): void {
+    if (highlight instanceof Entity) {
+      this._entities.remove(highlight);
+    } else {
+      this._groundPrimitives.remove(highlight);
+    }
+    this._activeHighlights.delete(highlight);
+  }
+
+  /**
+   * Clears all highlights.
+   */
+  clearAll(): void {
+    this._entities.remove('Highlight');
+    this._groundPrimitives.remove('Highlight');
+    this._activeHighlights.clear();
+  }
+
+  /**
+   * Sets the default highlight color.
+   * @param color The new default color for highlights
+   */
+  set defaultColor(color: Color) {
+    this._defaultColor = color;
+  }
+  /** Gets the default highlight color. */
+  get defaultColor(): Color {
+    return this._defaultColor;
+  }
+
+  /**
+   * Highlights a Ground Primitive.
+   * @private
+   * @param object The object containing a Ground Primitive
+   * @param color The color to use for the highlight
+   * @returns The created GroundPrimitive
+   *
+   * @todo Add `outline` option that creates polyline entity based on positions from the geometry.
+   */
+  private _highlightGroundPrimitive(
+    primitive: GroundPrimitive,
+    color: Color,
+  ): GroundPrimitive | undefined {
+    try {
+      const instances = primitive.geometryInstances;
+      const instance: GeometryInstance = Array.isArray(instances)
+        ? instances[0]
+        : instances;
+
+      if (!instance) return undefined;
+
+      // Create highlight primitive
+      const highlightPrimitive = new GroundPrimitive({
+        geometryInstances: new GeometryInstance({
+          geometry: instance.geometry,
+          attributes: {
+            color: Color.fromCssColorString(color.toCssColorString()),
+          },
+        }),
+        appearance: new PerInstanceColorAppearance({
+          flat: true,
+          translucent: true,
+        }),
+        classificationType: ClassificationType.BOTH,
+      });
+
+      // Add to collection
+      this._groundPrimitives.add(highlightPrimitive);
+      return highlightPrimitive;
+    } catch (error) {
+      console.error('Failed to highlight Ground Primitive:', error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Highlights an Entity.
+   * @private
+   * @param entity The Entity to highlight
+   * @param color The color to use for the highlight
+   * @returns The created Entity
+   */
+  private _highlightEntity(entity: Entity, color: Color): Entity | undefined {
+    try {
+      // Create properties for the highlight entity
+      const highlightOptions: Entity.ConstructorOptions = {
+        id: `highlight-${entity.id}`,
+      };
+
+      // Copy appropriate geometry from the original entity
+      if (entity.polygon) {
+        highlightOptions.polygon = {
+          hierarchy: entity.polygon.hierarchy?.getValue(),
+          material: color,
+          classificationType: ClassificationType.BOTH,
+        };
+      } else if (entity.polyline) {
+        highlightOptions.polyline = {
+          positions: entity.polyline.positions?.getValue(),
+          width: (entity.polyline.width?.getValue() || 2) + 2,
+          material: color,
+          clampToGround: true,
+        };
+      } else if (entity.rectangle) {
+        highlightOptions.rectangle = {
+          coordinates: entity.rectangle.coordinates?.getValue(),
+          material: color,
+        };
+      } else {
+        // Default highlighting for other entity types
+        highlightOptions.ellipsoid = {
+          radii: new Cartesian3(20, 20, 20),
+          material: color,
+        };
+        highlightOptions.position = entity.position?.getValue();
+      }
+
+      const highlightEntity = new Entity(highlightOptions);
+      this._entities.add(highlightEntity);
+      return highlightEntity;
+    } catch (error) {
+      console.error('Failed to highlight Entity:', error);
+      return undefined;
+    }
+  }
+
+  /** Gets a viewer which this class derived from. */
+  get viewer(): Viewer {
+    return this._viewer;
+  }
+
+  /** Gets a collection for `Entity` used to highlight. */
+  get entities(): Collection<EntityCollection, Entity> {
+    return this._entities;
+  }
+
+  /** Gets a collection for `GroundPrimitive` used to highlight. */
+  get groundPrimitives(): Collection<PrimitiveCollection, GroundPrimitive> {
+    return this._groundPrimitives;
+  }
+
+  /** Gets all active highlights */
+  get activeHighlights(): Set<Entity | GroundPrimitive> {
+    return this._activeHighlights;
+  }
+}
+
+export { Highlight };

--- a/src/viewer/index.ts
+++ b/src/viewer/index.ts
@@ -1,2 +1,3 @@
 export { cloneViewer } from './clone.js';
+export { Highlight } from './highlight.js';
 export { syncCamera } from './sync-camera.js';


### PR DESCRIPTION
* New `Highlight` class for highlighting objects. A multiton class that supports multi-viewer situation. Handles mainly the object returned from `scene.pick()` or `drillPick()`.

* Fix mocks for tests. Extend viewer mock to have collections. (primitives, entities, groundPrimives) Add a simple collection mock.

* New test conducted for `Highlight`. In Progress.