### PR TITLE
fix: Simplify class to use single type of collection

### DIFF
--- a/.changeset/fine-peas-swim.md
+++ b/.changeset/fine-peas-swim.md
@@ -1,0 +1,18 @@
+---
+"@juun-roh/cesium-utils": patch
+---
+
+Simplify Class
+
+fix: Simplify class to use single type of collection
+
+* Remove internal `Primitive` collection.  
+Replace highlight object to be type of `Entity`.  
+Replace `GroundPrimitive` instances logics with `Entity`.  
+
+* Replace viewer identifier.  
+Use DOM element, the container of viewer instance as an identifier of the viewer.  
+
+* Update viewer mock to have container property.
+
+* Update test to match fixed class.

--- a/src/__mocks__/cesium.ts
+++ b/src/__mocks__/cesium.ts
@@ -118,6 +118,7 @@ const createMockViewer = (overrides?: Partial<CViewer>) =>
       fullscreenButton: true,
       infoBox: true,
 
+      container: document.createElement('div'),
       camera: createMockCamera(overrides?.camera),
       clock: createMockClock(overrides?.clock),
       entities: vi.fn().mockImplementation(() => ({})),

--- a/src/__tests__/viewer/highlight.test.ts
+++ b/src/__tests__/viewer/highlight.test.ts
@@ -21,7 +21,6 @@ describe('Highlight', () => {
     it('should create new instance from a single viewer only once', () => {
       expect(highlight).toBeDefined();
       expect(highlight.defaultColor).toEqual(Color.YELLOW.withAlpha(0.5));
-      expect(highlight.viewer).toEqual(viewer);
 
       expect(Highlight.getInstance(viewer)).toEqual(highlight);
     });
@@ -39,17 +38,17 @@ describe('Highlight', () => {
       const highlight = Highlight.getInstance(viewer);
       const clearAllSpy = vi.spyOn(highlight, 'clearAll');
       const instancesMap = Highlight['instances'];
-      expect(instancesMap.has(viewer)).toBe(true);
-      expect(instancesMap.get(viewer)).toBe(highlight);
+      expect(instancesMap.has(viewer.container)).toBe(true);
+      expect(instancesMap.get(viewer.container)).toBe(highlight);
 
       Highlight.releaseInstance(viewer);
 
       expect(clearAllSpy).toHaveBeenCalledTimes(1);
-      expect(instancesMap.has(viewer)).toBe(false);
+      expect(instancesMap.has(viewer.container)).toBe(false);
 
       const newHighlight = Highlight.getInstance(viewer);
       expect(newHighlight).not.toBe(highlight);
-      expect(instancesMap.get(viewer)).toBe(newHighlight);
+      expect(instancesMap.get(viewer.container)).toBe(newHighlight);
     });
 
     it('should handle releasing non-existent instances', () => {
@@ -87,6 +86,7 @@ describe('Highlight', () => {
       expect(highlight['_highlightGroundPrimitive']).toBeCalledWith(
         objectWithPrimitive.primitive,
         color,
+        false,
       );
     });
 


### PR DESCRIPTION
* Remove internal `Primitive` collection. Replace highlight object to be type of `Entity`.
Replace `GroundPrimitive` instances logics with `Entity`.

* Replace viewer identifier. Use DOM element, the container of viewer instance as an identifier of the viewer.

* Update viewer mock to have container property.

* Update test to match fixed class.