### PR TITLE
fix: Model entity highlight

### DIFF
--- a/.changeset/giant-worms-play.md
+++ b/.changeset/giant-worms-play.md
@@ -1,0 +1,10 @@
+---
+"@juun-roh/cesium-utils": patch
+---
+
+Bug Fix
+
+fix: Model entity highlight
+
+* Setting `entity.model.silhouetteColor` to `undefined` does not properly remove the applied silhouette color.  
+Restore setting it from `undefined` to `Color.TRANSPARENT`.

--- a/src/__tests__/highlight/silhouette-highlight.test.ts
+++ b/src/__tests__/highlight/silhouette-highlight.test.ts
@@ -153,7 +153,9 @@ describe("Silhouette Highlight", () => {
 
         highlight.hide();
 
-        expect(entity.model?.silhouetteColor).toBeUndefined();
+        expect(entity.model?.silhouetteColor?.getValue()).toEqual(
+          Color.TRANSPARENT,
+        );
         expect(highlight["_entity"]).toBeUndefined();
       });
     });

--- a/src/highlight/silhouette-highlight.ts
+++ b/src/highlight/silhouette-highlight.ts
@@ -90,7 +90,9 @@ export default class SilhouetteHighlight implements IHighlight {
   hide(): void {
     if (this._silhouette.selected.length > 0) this._silhouette.selected = [];
     if (this._entity?.model) {
-      this._entity.model.silhouetteColor = undefined;
+      this._entity.model.silhouetteColor = new ConstantProperty(
+        Color.TRANSPARENT,
+      );
       this._entity = undefined;
     }
   }


### PR DESCRIPTION
* Setting `entity.model.silhouetteColor` to `undefined` does not properly remove the applied silhouette color. Restore setting it from `undefined` to `Color.TRANSPARENT`.